### PR TITLE
fix sidebar width issues

### DIFF
--- a/r2/r2/public/static/css/reddit.less
+++ b/r2/r2/public/static/css/reddit.less
@@ -468,6 +468,7 @@ ul.flat-vert {text-align: left;}
     background-color: white; 
     margin: 0px 5px 0 5px;
     width: 300px;
+    overflow-x: scroll;
 }
 
 .side .spacer {


### PR DESCRIPTION
Many subreddits don't test their sidebar content with custom CSS turned off, and they have content that is too wide, causing the entire document to scroll left and right. overflow-x: scroll will make just the sidebar scroll horizontally instead.
